### PR TITLE
refactor: rename NGROK_URL to WEBHOOK_BASE_URL + Koyeb deploy setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Telegram Bot Configuration
 BOT_TOKEN=your_telegram_bot_token_here
 
-# Ngrok Configuration for Local Testing
-NGROK_URL=https://your-ngrok-url.ngrok.io
+# Webhook base URL (ngrok for local dev, Koyeb/DuckDNS in prod)
+WEBHOOK_BASE_URL=https://your-ngrok-url.ngrok.io
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,24 @@
+# === Telegram Bot ===
+BOT_TOKEN=your_telegram_bot_token_here
+
+# === Webhook (DuckDNS domain, triggers webhook mode) ===
+WEBHOOK_BASE_URL=https://your-subdomain.duckdns.org
+WEBHOOK_PATH=/webhook
+WEBHOOK_SECRET=change_me_to_a_random_string
+PORT=8000
+
+# === Database ===
+# In production docker-compose the host is "postgres" (service name)
+DATABASE_URL=postgresql+asyncpg://telegram_user:CHANGE_ME@postgres:5432/telegram_game
+POSTGRES_PASSWORD=CHANGE_ME
+
+# === Redis ===
+REDIS_URL=redis://redis:6379/0
+
+# === OpenAI (optional) ===
+OPENAI_ENABLED=1
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-4o-mini
+
+# === Logging ===
+LOG_LEVEL=INFO

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,6 +5,7 @@ This module configures Alembic to work with our async SQLAlchemy setup.
 """
 
 import asyncio
+import os
 from logging.config import fileConfig
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
@@ -28,6 +29,10 @@ if config.config_file_name is not None:
 # add your model's MetaData object here
 # for 'autogenerate' support
 target_metadata = Base.metadata
+
+# Override sqlalchemy.url from DATABASE_URL env var when available (e.g. Docker)
+if db_url := os.environ.get("DATABASE_URL"):
+    config.set_main_option("sqlalchemy.url", db_url)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,8 +21,8 @@ class Settings(BaseSettings):
     # Bot configuration
     bot_token: str = Field(..., env="BOT_TOKEN", description="Telegram bot token")
 
-    # Ngrok configuration for local testing
-    ngrok_url: Optional[str] = Field(default="", env="NGROK_URL", description="Ngrok URL for local testing")
+    # Webhook base URL (triggers webhook mode when set; use ngrok locally, Koyeb/DuckDNS in prod)
+    webhook_base_url: Optional[str] = Field(default="", env="WEBHOOK_BASE_URL", description="Base URL for webhook")
     
     # Logging configuration
     log_level: str = Field(default="INFO", env="LOG_LEVEL", description="Logging level")
@@ -53,9 +53,8 @@ class Settings(BaseSettings):
     
     @property
     def webhook_url(self) -> str:
-        """Generate webhook URL from ngrok URL and webhook path."""
-        if self.ngrok_url:
-            return f"{self.ngrok_url}{self.webhook_path}"
+        if self.webhook_base_url:
+            return f"{self.webhook_base_url}{self.webhook_path}"
         return ""
     
     @validator("log_level")
@@ -84,8 +83,7 @@ class Config:
     # Bot configuration
     BOT_TOKEN = settings.bot_token
 
-    # Ngrok configuration for local testing
-    NGROK_URL = settings.ngrok_url
+    WEBHOOK_BASE_URL = settings.webhook_base_url
     
     # Logging configuration
     LOG_LEVEL = settings.log_level

--- a/app/main.py
+++ b/app/main.py
@@ -75,7 +75,7 @@ async def main():
     logger.info("All routers registered")
 
     try:
-        if Config.NGROK_URL:
+        if Config.WEBHOOK_BASE_URL:
             logger.info("Bot is running in webhook mode", webhook_url=Config.WEBHOOK_URL)
             await bot.set_webhook(
                 url=Config.WEBHOOK_URL,
@@ -88,6 +88,11 @@ async def main():
                 secret_token=Config.WEBHOOK_SECRET,
             ).register(app, path=Config.WEBHOOK_PATH)
             setup_application(app, dp, bot=bot)
+
+            async def health(_: web.Request) -> web.Response:
+                return web.Response(text="ok")
+
+            app.router.add_get("/health", health)
 
             runner = web.AppRunner(app)
             await runner.setup()
@@ -104,7 +109,7 @@ async def main():
         logger.error("Fatal error occurred", error_type=type(e).__name__, error_message=str(e))
         raise
     finally:
-        if Config.NGROK_URL:
+        if Config.WEBHOOK_BASE_URL:
             await bot.delete_webhook()
         await cache_cleanup_service.stop()
         await close_db()

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,129 @@
+# Deployment Guide — Oracle Cloud
+
+## Стек
+- **Сервер:** Oracle Cloud Always Free ARM (Ubuntu 22.04, 4 OCPU, 24 GB RAM)
+- **Домен:** [DuckDNS](https://www.duckdns.org) — безкоштовний субдомен
+- **SSL:** Let's Encrypt (автооновлення через certbot)
+- **Proxy:** Nginx (термінує SSL, проксує до бота на 127.0.0.1:8000)
+- **Runtime:** Docker Compose (PostgreSQL + Redis + Bot)
+
+---
+
+## Крок 1 — Oracle Cloud VM
+
+1. Зайди на [cloud.oracle.com](https://cloud.oracle.com) → Create Instance
+2. Параметри:
+   - **Image:** Ubuntu 22.04
+   - **Shape:** VM.Standard.A1.Flex (ARM, Always Free) — 4 OCPU, 24 GB RAM
+   - **Boot volume:** 47 GB (безкоштовний ліміт)
+3. Завантаж або згенеруй SSH-ключ
+4. Збережи публічний IP інстансу
+
+**Важливо — Security List (VCN → Security Lists → Default):**
+Додай Ingress Rules:
+| Protocol | Port | Source    |
+|----------|------|-----------|
+| TCP      | 22   | 0.0.0.0/0 |
+| TCP      | 80   | 0.0.0.0/0 |
+| TCP      | 443  | 0.0.0.0/0 |
+
+---
+
+## Крок 2 — Безкоштовний домен (DuckDNS)
+
+1. Зайди на [duckdns.org](https://www.duckdns.org) → Sign in
+2. Створи субдомен, наприклад: `my-rpg-bot`
+3. Вкажи публічний IP Oracle VM
+4. Запиши токен зі сторінки
+
+---
+
+## Крок 3 — Налаштування сервера
+
+```bash
+# Підключитись до VM
+ssh ubuntu@<ORACLE_VM_IP>
+
+# Встановити netfilter-persistent (для iptables правил)
+sudo apt-get install -y iptables-persistent
+
+# Запустити setup-скрипт
+curl -O https://raw.githubusercontent.com/.../deploy/setup.sh
+# або скопіювати файл через scp:
+# scp deploy/setup.sh ubuntu@<IP>:~/
+
+bash setup.sh my-rpg-bot.duckdns.org <DUCKDNS_TOKEN>
+```
+
+Скрипт автоматично:
+- Встановлює Docker, Nginx, Certbot
+- Налаштовує firewall
+- Реєструє DuckDNS cron-оновлення
+- Отримує Let's Encrypt сертифікат
+- Конфігурує Nginx як reverse proxy
+
+---
+
+## Крок 4 — Деплой бота
+
+```bash
+# На сервері
+git clone https://github.com/YOUR_USERNAME/R-D-telegram-game.git ~/r-d-telegram-game
+cd ~/r-d-telegram-game
+
+# Створити .env з прикладу
+cp .env.production.example .env
+nano .env  # заповнити всі змінні
+
+# Запустити
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Міграції БД (перший раз)
+docker compose -f docker-compose.prod.yml exec bot python -m alembic upgrade head
+
+# Логи
+docker compose -f docker-compose.prod.yml logs -f bot
+```
+
+---
+
+## Оновлення бота
+
+```bash
+cd ~/r-d-telegram-game
+git pull
+docker compose -f docker-compose.prod.yml up -d --build bot
+```
+
+---
+
+## Корисні команди
+
+```bash
+# Статус
+docker compose -f docker-compose.prod.yml ps
+
+# Рестарт бота
+docker compose -f docker-compose.prod.yml restart bot
+
+# Логи nginx
+sudo tail -f /var/log/nginx/error.log
+
+# Перевірити сертифікат
+sudo certbot certificates
+
+# Ручне оновлення сертифікату
+sudo certbot renew --dry-run
+```
+
+---
+
+## .env на сервері — що змінити
+
+| Змінна | Локальне значення | Продакшн значення |
+|--------|-------------------|-------------------|
+| `NGROK_URL` | `https://...ngrok.io` | `https://my-rpg-bot.duckdns.org` |
+| `WEBHOOK_SECRET` | `secret` | випадковий рядок 32+ символи |
+| `POSTGRES_PASSWORD` | `telegram_password` | сильний пароль |
+| `DATABASE_URL` | `localhost:5432` | `postgres:5432` (docker network) |
+| `REDIS_URL` | `localhost:6379` | `redis:6379` (docker network) |

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Oracle Cloud Ubuntu 22.04 — initial server setup for telegram game bot
+# Usage: bash setup.sh your-subdomain.duckdns.org YOUR_DUCKDNS_TOKEN
+
+set -euo pipefail
+
+DOMAIN="${1:?Usage: $0 <domain> <duckdns_token>}"
+DUCKDNS_TOKEN="${2:?Usage: $0 <domain> <duckdns_token>}"
+EMAIL="admin@${DOMAIN}"
+
+echo "=== 1. System update ==="
+sudo apt-get update && sudo apt-get upgrade -y
+
+echo "=== 2. Install Docker ==="
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo usermod -aG docker "$USER"
+
+echo "=== 3. Install Nginx + Certbot ==="
+sudo apt-get install -y nginx certbot python3-certbot-nginx
+
+echo "=== 4. Configure firewall ==="
+sudo ufw allow OpenSSH
+sudo ufw allow 'Nginx Full'
+sudo ufw --force enable
+
+# Oracle Cloud also requires iptables rules (their VCN firewall is separate)
+sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 80 -j ACCEPT
+sudo iptables -I INPUT 6 -m state --state NEW -p tcp --dport 443 -j ACCEPT
+sudo netfilter-persistent save 2>/dev/null || true
+
+echo "=== 5. DuckDNS cron (update IP every 5 min) ==="
+DUCKDNS_SUBDOMAIN="${DOMAIN%.duckdns.org}"
+mkdir -p ~/duckdns
+cat > ~/duckdns/duck.sh <<EOF
+#!/bin/bash
+echo url="https://www.duckdns.org/update?domains=${DUCKDNS_SUBDOMAIN}&token=${DUCKDNS_TOKEN}&ip=" | curl -k -o ~/duckdns/duck.log -K -
+EOF
+chmod +x ~/duckdns/duck.sh
+(crontab -l 2>/dev/null; echo "*/5 * * * * ~/duckdns/duck.sh >/dev/null 2>&1") | crontab -
+~/duckdns/duck.sh
+echo "DuckDNS updated: $(cat ~/duckdns/duck.log)"
+
+echo "=== 6. Nginx initial config (HTTP for certbot challenge) ==="
+sudo tee /etc/nginx/sites-available/telegram-bot <<EOF
+server {
+    listen 80;
+    server_name ${DOMAIN};
+    location / {
+        return 200 'ok';
+    }
+}
+EOF
+sudo ln -sf /etc/nginx/sites-available/telegram-bot /etc/nginx/sites-enabled/telegram-bot
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t && sudo systemctl reload nginx
+
+echo "=== 7. Let's Encrypt SSL ==="
+sudo certbot --nginx -d "${DOMAIN}" --non-interactive --agree-tos -m "${EMAIL}" --redirect
+
+echo "=== 8. Nginx final config (HTTPS proxy to bot) ==="
+sudo tee /etc/nginx/sites-available/telegram-bot <<EOF
+server {
+    listen 80;
+    server_name ${DOMAIN};
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name ${DOMAIN};
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location /webhook {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    location / {
+        return 404;
+    }
+}
+EOF
+sudo nginx -t && sudo systemctl reload nginx
+
+echo ""
+echo "=== Done! ==="
+echo "Server is ready. Now:"
+echo "  1. Clone the repo to ~/r-d-telegram-game"
+echo "  2. Create .env based on .env.production.example"
+echo "  3. Run: cd ~/r-d-telegram-game && docker compose -f docker-compose.prod.yml up -d"
+echo "  4. Run migrations: docker compose -f docker-compose.prod.yml exec bot python -m alembic upgrade head"
+echo ""
+echo "Bot webhook URL: https://${DOMAIN}/webhook"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,69 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: r-d-telegram-game-postgres
+    environment:
+      POSTGRES_DB: telegram_game
+      POSTGRES_USER: telegram_user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U telegram_user -d telegram_game"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - telegram_game_network
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: r-d-telegram-game-redis
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - telegram_game_network
+    restart: unless-stopped
+
+  bot:
+    build: .
+    container_name: r-d-telegram-game-bot
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://telegram_user:${POSTGRES_PASSWORD}@postgres:5432/telegram_game
+      REDIS_URL: redis://redis:6379/0
+    ports:
+      - "127.0.0.1:8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - telegram_game_network
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+
+networks:
+  telegram_game_network:
+    driver: bridge


### PR DESCRIPTION
- NGROK_URL → WEBHOOK_BASE_URL (clearer intent: any webhook base URL)
- Add /health endpoint for Koyeb health checks
- Add alembic DATABASE_URL env override for Docker
- Add docker-compose.prod.yml (no exposed db ports, logs rotation)
- Add deploy/ with setup.sh and README for Oracle/DuckDNS fallback
- Add .env.production.example