### PR TITLE
fix: resolve Upstash ConnectionError and webhook URL double-slash

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -80,7 +80,7 @@ class Settings(BaseSettings):
     @property
     def webhook_url(self) -> str:
         if self.webhook_base_url:
-            return f"{self.webhook_base_url}{self.webhook_path}"
+            return f"{self.webhook_base_url.rstrip('/')}{self.webhook_path}"
         return ""
     
     @validator("log_level")

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -33,9 +33,11 @@ async def init_redis() -> None:
     # Create connection pool
     pool = ConnectionPool.from_url(
         settings.redis_url,
-        max_connections=20,
+        max_connections=10,
         retry_on_timeout=True,
-        decode_responses=False,  # We'll handle encoding/decoding manually
+        health_check_interval=30,  # ping idle connections before use (fixes Upstash server-side close)
+        socket_keepalive=True,
+        decode_responses=False,
     )
     
     # Create Redis client


### PR DESCRIPTION
- Add health_check_interval=30 and socket_keepalive=True to Redis pool to prevent "Connection closed by server" on idle connections (Upstash)
- Reduce max_connections 20→10 for Upstash free tier limits
- Fix webhook_url to strip trailing slash before appending path