### PR TITLE
fix: add full traceback to error handler logging

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -4,6 +4,7 @@ Core utilities for the Telegram RPG game bot.
 This module contains common utility functions used across the application.
 """
 
+import traceback as tb
 from typing import Any, Dict, Optional
 from aiogram.types import TelegramObject, Update
 
@@ -92,4 +93,5 @@ def format_exception(exception: Exception) -> Dict[str, Any]:
         'type': type(exception).__name__,
         'message': str(exception),
         'module': getattr(exception, '__module__', None),
+        'traceback': ''.join(tb.format_exception(type(exception), exception, exception.__traceback__)),
     }

--- a/app/handlers/errors.py
+++ b/app/handlers/errors.py
@@ -69,7 +69,8 @@ def setup_error_handlers(router: Router) -> None:
                 user_id=update_info.get('user_id'),
                 chat_id=update_info.get('chat_id'),
                 error_type=type(error).__name__,
-                error_message=str(error)
+                error_message=str(error),
+                traceback=format_exception(error),
             )
             
         except Exception as e:


### PR DESCRIPTION
errors_handler logged only error_type/message — no stack trace, making root cause of ConnectionError invisible.

format_exception now includes traceback field; errors_handler passes it to logs.