### PR TITLE
fix: switch FSM storage from Redis to MemoryStorage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,10 @@ import asyncio
 from aiohttp import web
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
-from aiogram.fsm.storage.redis import RedisStorage
+from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
 from app.core.config import Config
-from app.core.redis import init_redis, close_redis, get_redis
+from app.core.redis import init_redis, close_redis
 from app.core.db import init_db, close_db
 from app.handlers.commands import start_router, game_router, language_router, character_router
 from app.handlers.menu import router as menu_router
@@ -38,11 +38,9 @@ async def main():
     logger.info("Initializing Redis connection...")
     await init_redis()
 
-    redis_client = get_redis()
-    storage = RedisStorage(redis=redis_client)
-
+    # FSM uses MemoryStorage — state is persisted to PostgreSQL via FSMStateService
     bot = Bot(token=Config.BOT_TOKEN, default=DefaultBotProperties(parse_mode="HTML"))
-    dp = Dispatcher(storage=storage)
+    dp = Dispatcher(storage=MemoryStorage())
 
     dp.message.middleware(GlobalErrorHandler())
     dp.callback_query.middleware(GlobalErrorHandler())


### PR DESCRIPTION
RedisStorage.get_state() fails during on_connect() auth phase — redis-py Retry doesn't cover connection establishment, only command execution.

FSM state is already persisted to PostgreSQL via FSMStateService and restored by DatabaseMiddleware on every request, so RedisStorage is a redundant point of failure. Redis remains in use for caching only.